### PR TITLE
:bricks: Load balancer setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,3 +81,9 @@ devops/terraform/redeploy: devops/terraform/select/$(WORKSPACE)
 
 devops/terraform/destroy/all: devops/terraform/select/$(WORKSPACE)
 	terraform -chdir=terraform destroy
+
+devops/terraform/output: devops/terraform/select/$(WORKSPACE)
+	terraform -chdir=terraform output
+
+devops/terraform/output/load_balancer_ip: devops/terraform/select/$(WORKSPACE)
+	terraform -chdir=terraform output load_balancer_ip

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Automates the [Ping explorer](https://github.com/ping-pub/explorer) deployment t
 
 Also patches the explorer to add a Canto testnet that links to the our full nodes.
 
-<https://ping-explorer-3mid33wd4a-uc.a.run.app/canto/staking?testnet>
+- <https://testnet-ping-explorer.ansybl.io/>
+- <https://ping-explorer.ansybl.io/>
 
 ## Build
 Download, patch and build locally before using.

--- a/terraform/load_balancer.tf
+++ b/terraform/load_balancer.tf
@@ -1,0 +1,44 @@
+resource "google_compute_region_network_endpoint_group" "this" {
+  count                 = var.create_load_balancer ? 1 : 0
+  project               = var.project
+  name                  = "${local.service_name}-neg-${local.environment}"
+  network_endpoint_type = "SERVERLESS"
+  region                = var.region
+  cloud_run {
+    service = google_cloud_run_service.default.name
+  }
+}
+
+module "load_balancer" {
+  count   = var.create_load_balancer ? 1 : 0
+  source  = "GoogleCloudPlatform/lb-http/google//modules/serverless_negs"
+  version = "6.3.0"
+  project = var.project
+  name    = "${local.service_name}-load-balancer-${local.environment}"
+
+  backends = {
+    default = {
+      description = null
+      groups = [
+        {
+          group = google_compute_region_network_endpoint_group.this[0].id
+        }
+      ]
+      enable_cdn              = false
+      security_policy         = null
+      custom_request_headers  = null
+      custom_response_headers = null
+
+      iap_config = {
+        enable               = false
+        oauth2_client_id     = null
+        oauth2_client_secret = null
+      }
+
+      log_config = {
+        enable      = true
+        sample_rate = 1.0
+      }
+    }
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -13,6 +13,13 @@ provider "google" {
   zone        = var.zone
 }
 
+provider "google-beta" {
+  project     = var.project
+  credentials = file(var.credentials)
+  region      = var.region
+  zone        = var.zone
+}
+
 resource "google_storage_bucket" "default" {
   name          = "ping-explorer-infra-bucket-tfstate"
   force_destroy = false
@@ -28,7 +35,7 @@ resource "google_project_service" "cloud_run_api" {
 }
 
 resource "google_cloud_run_service" "default" {
-  name     = local.service_name
+  name     = "${local.service_name}-frontend-${local.environment}"
   location = var.region
 
   template {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,3 @@
+output "load_balancer_ip" {
+  value = module.load_balancer[0].external_ip
+}

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -5,3 +5,5 @@ credentials = "../terraform-service-key.json"
 project = "dfpl-playground"
 region  = "us-central1"
 zone    = "us-central1-a"
+
+create_load_balancer = true

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -23,6 +23,11 @@ variable "image_tag" {
   default = "latest"
 }
 
+variable "create_load_balancer" {
+  type    = bool
+  default = false
+}
+
 locals {
   environment  = terraform.workspace
   service_name = "ping-explorer"


### PR DESCRIPTION
Cloud Run doesn't seem to support mapping domains from CloudFlare CNAME.
Introduce a load balancer for more flexibility.
On the CloudFlare side we can simply point a A DNS type to the LB IP.
Note this setup is optional and disabled by default, but can be enabled via the `create_load_balancer` variable.