### PR TITLE
:wrench: Reserve load balancer IP

### DIFF
--- a/canto-testnet.patch
+++ b/canto-testnet.patch
@@ -6,8 +6,8 @@ index 0000000..65625a2
 @@ -0,0 +1,19 @@
 +{
 +  "chain_name": "canto",
-+  "api": ["https://node1.canto.ansybl.io", "https://node2.canto.ansybl.io"],
-+  "rpc": ["https://34.27.34.118:26657", "https://34.171.23.136:26657"],
++  "api": ["https://canto-node1.ansybl.io/api", "https://canto-node2.ansybl.io/api"],
++  "rpc": ["https://canto-node1.ansybl.io/rpc", "https://canto-node2.ansybl.io/rpc"],
 +  "snapshot_provider": "",
 +  "sdk_version": "0.45.6",
 +  "coin_type": "60",

--- a/terraform/addresses.tf
+++ b/terraform/addresses.tf
@@ -1,0 +1,4 @@
+resource "google_compute_global_address" "load_balancer_address" {
+  name       = "${local.service_name}-load-balancer-address-${local.environment}"
+  ip_version = "IPV4"
+}

--- a/terraform/load_balancer.tf
+++ b/terraform/load_balancer.tf
@@ -10,11 +10,13 @@ resource "google_compute_region_network_endpoint_group" "this" {
 }
 
 module "load_balancer" {
-  count   = var.create_load_balancer ? 1 : 0
-  source  = "GoogleCloudPlatform/lb-http/google//modules/serverless_negs"
-  version = "6.3.0"
-  project = var.project
-  name    = "${local.service_name}-load-balancer-${local.environment}"
+  count          = var.create_load_balancer ? 1 : 0
+  source         = "GoogleCloudPlatform/lb-http/google//modules/serverless_negs"
+  version        = "6.3.0"
+  project        = var.project
+  name           = "${local.service_name}-load-balancer-${local.environment}"
+  create_address = false
+  address        = google_compute_global_address.load_balancer_address.address
 
   backends = {
     default = {
@@ -37,7 +39,7 @@ module "load_balancer" {
 
       log_config = {
         enable      = true
-        sample_rate = 1.0
+        sample_rate = 0.01
       }
     }
   }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,3 +1,7 @@
 output "load_balancer_ip" {
   value = module.load_balancer[0].external_ip
 }
+
+output "nginx_reverse_proxy_url" {
+  value = google_cloud_run_service.default.status.0.url
+}


### PR DESCRIPTION
Reserve the load balancer IP.
Adjust the log sample to a lower rate.
Update the RPC nodes to match the new hostname.